### PR TITLE
Fixed compilation for neither-boost-nor-c++11 case.

### DIFF
--- a/include/mms/features/type_traits/intrinsics.h
+++ b/include/mms/features/type_traits/intrinsics.h
@@ -37,7 +37,7 @@
 namespace mms {
 namespace type_traits {
 
-template<class T> struct is_trivial { static const bool value == __is_pod(T); };
+template<class T> struct is_trivial { static const bool value = __is_pod(T); };
 template<class B, class D> struct is_base_of { static const bool value = __is_base_of(B, D); };
 
 template<bool C, class T> struct enable_if {};

--- a/include/mms/string.h
+++ b/include/mms/string.h
@@ -177,8 +177,9 @@ inline bool operator ==(const impl::StringRef& a, const impl::StringRef& b)
 inline bool operator !=(const impl::StringRef& a, const impl::StringRef& b)
     { return impl::StringRef::strcmp<std::not_equal_to>(a, b); }
 
-
+#ifdef MMS_FEATURES_HASH
 inline size_t hash_value(const string<Mmapped>& s)
     { return impl::hash_range(s.begin(), s.end()); }
+#endif
 
 } // namespace mms


### PR DESCRIPTION
There were several compilation errors when I tried to compile
example.cpp with command line:
    g++ -Iinclude example.cpp
