### PR TITLE
Add default ctor to optional

### DIFF
--- a/include/mms/optional.h
+++ b/include/mms/optional.h
@@ -47,6 +47,10 @@ private:
     typedef bool (optional::*unspecified_bool_type)() const;
 
 public:
+    optional()
+    {
+    }
+
     optional(const optional& c)
         : impl::Offset(c)
     {


### PR DESCRIPTION
Required to generate default ctors in class accumulating optional fields.