### PR TITLE
Make MMS compile with MSVS2015

### DIFF
--- a/include/mms/impl/container.h
+++ b/include/mms/impl/container.h
@@ -61,17 +61,17 @@ public:
     bool isNull() const { return offset_ == 0; }
 
 protected:
-    ssize_t offset_;
+    std::ptrdiff_t offset_;
 
     template<class T>
-    const T* ptr(const ssize_t& offset) const
+    const T* ptr(const std::ptrdiff_t& offset) const
     {
         return reinterpret_cast<const T*>(
             reinterpret_cast<const char*>(&offset) + offset
         );
     }
 
-    ssize_t offset(const void* ptr) const
+    std::ptrdiff_t offset(const void* ptr) const
     {
         return reinterpret_cast<const char*>(ptr) -
                reinterpret_cast<const char*>(this);

--- a/include/mms/impl/fwd.h
+++ b/include/mms/impl/fwd.h
@@ -41,6 +41,6 @@ template<class P, class T> class vector;
 template<class P, class T> class optional;
 template<class P> class string;
 
-typedef size_t FormatVersion;
+typedef uint32_t FormatVersion;
 
 }//namespace mms

--- a/include/mms/impl/writer-impl.h
+++ b/include/mms/impl/writer-impl.h
@@ -35,6 +35,7 @@
 #include "../type_traits.h"
 #include "../version.h"
 
+#include <algorithm>
 #include <vector>
 #include <stdexcept>
 #include <iostream>
@@ -83,7 +84,9 @@ inline bool isAligned(size_t pos, size_t size, size_t alignment = sizeof(void*))
 template<class Writer>
 inline void align(Writer& w, size_t alignment = sizeof(void*))
 {
-    addZeroes(w, (-w.pos()) & (sanitizeAlignment(alignment) - 1));
+    alignment = sanitizeAlignment(alignment);
+    auto zeroes_count = ((w.pos() + alignment - 1) & ~(alignment - 1)) - w.pos();
+    addZeroes(w, zeroes_count);
 }
 
 template<class Writer>
@@ -166,7 +169,7 @@ public:
     
     void addPointee(size_t& pos) { pointees_.push_back(&pos); }
     
-    void adjustPointees(ssize_t diff)
+    void adjustPointees(std::ptrdiff_t diff)
     {
         for (std::vector<size_t*>::iterator i = pointees_.begin(), ie = pointees_.end(); i != ie; ++i)
             **i += diff;

--- a/include/mms/version.h
+++ b/include/mms/version.h
@@ -82,7 +82,7 @@ public:
 
     Ver combine(Ver lhs, Ver rhs)
     {
-        static const size_t FORMAT_POLYNOMIAL_COEF = 478278233;
+        static const uint32_t FORMAT_POLYNOMIAL_COEF = 478278233;
         return lhs * FORMAT_POLYNOMIAL_COEF + rhs;
     }
 
@@ -94,9 +94,9 @@ public:
     static Ver hash(const char* str)
     {
         // Stolen from boost::hash_combine()
-        size_t h = 0;
+        uint32_t h = 0;
         for (; *str; ++str)
-            h ^= static_cast<size_t>(*str) + 0x9e3779b9 + (h << 6) + (h >> 2);
+            h ^= static_cast<uint32_t>(*str) + 0x9e3779b9 + (h << 6) + (h >> 2);
         return h;
     }
 


### PR DESCRIPTION
Библиотека не собиралась MSVS2015, теперь может.
1 замена  ssize_t - > std::ptrdiff_t
2 кажется версия предполагалась размером 32бита
3 унарный минус не может применятся к беззнаковому типу, по этому переделал метод align
